### PR TITLE
Problem: unable to refer to test/main with absolute path

### DIFF
--- a/mods/rkt/cardano-wallet/main.rkt
+++ b/mods/rkt/cardano-wallet/main.rkt
@@ -6,12 +6,15 @@
 (require fractalide/modules/rkt/rkt-fbp/scheduler)
 (require (prefix-in graph: fractalide/modules/rkt/rkt-fbp/graph))
 
+; Required to make the resolved-module-path below valid
+(require fractalide/modules/rkt/rkt-fbp/agents/test/main)
+
 (module+ main
   (define sched (make-scheduler #f))
   (setup-fvm sched)
   (sched (msg-mesg "sched" "acc" (make-scheduler #f)))
   (sched (msg-mesg "halt" "in" #f))
-  (define path (fbp-agents-lookup "test/main.rkt"))
+  (define path (make-resolved-module-path (fbp-agents-lookup "test/main.rkt")))
   (define a-graph (graph:make-graph (graph:node "main" path)))
   (sched (msg-mesg "fvm" "in" (cons 'add a-graph)))
   (sched (msg-mesg "fvm" "in" (cons 'stop #t)))

--- a/mods/rkt/catalog.rktd
+++ b/mods/rkt/catalog.rktd
@@ -440,12 +440,12 @@
        .
        #hash((nix-sha256
               .
-              "0bnn7x4zhpcd0wqhky1jccgwdqw1mnrxmh2s0l46nz45nxzqwyxm")
+              "15pazyv4w7d4f2fjh5sg3762d0ip5g9nd5b2nx0g53cc2mgrs0fv")
              (dependencies
               .
               ("base" "gui-lib" "typed-map-lib" "typed-racket-more"))
              (name . "fractalide")
-             (checksum . "1da5b3022aca31785d39e063c37367834075c444")
+             (checksum . "bbc499e79b076cf482338f587097a91244b69958")
              (source . "https://github.com/fractalide/fractalide")))
       ("draw-lib"
        .

--- a/mods/rkt/catalog.rktd.in
+++ b/mods/rkt/catalog.rktd.in
@@ -3,7 +3,7 @@
         .
         #hash((dependencies .  ("base" "gui-lib" "typed-map-lib" "typed-racket-more"))
               (name . "fractalide")
-              (checksum . "1da5b3022aca31785d39e063c37367834075c444")
+              (checksum . "bbc499e79b076cf482338f587097a91244b69958")
               (source . "https://github.com/fractalide/fractalide")))
 ("cardano-wallet" .
 #hash((author . "claes.wallin@greatsinodevelopment.com") (checksum . "") (dependencies . ("base" "fvm")) (description . "Cardano Wallet implementation in Racket, using the Fractalide Flow-Based Programming scheduler") (modules . ((lib "cardano-wallet/main.rkt"))) (name . "cardano-wallet") (source . "./cardano-wallet") (tags . ()))


### PR DESCRIPTION
Solution: Bump to fractalide/fractalide#188

You still need to be in a checked out fractalide/fractalide in the
directory `modules/rkt/rkt-fbp` for fvm to be able to find
`to-close`, but we are now able to run the GUI from a semi-external
graph definition!

It works if you check both repos out, `raco link` them and run:

    racket -l- cardano-wallet/main

Alternatively, you can `raco setup` and then run:

    ~/.racket/6.12/bin/cardano-wallet

Hypothetically you should have been able to test with:

  $ nix-shell -p $(nix-build /path/to/cardano-wallet) --run \
    'cd /path/to/fractalide/modules/rkt/rkt-fbp && cardano-wallet'

But this runs into another issue, which is the next thing to solve:

```
hash-ref: no value found for key
  key: "main-vp"
  context...:
   /nix/store/dm8yah829czzws2x6pkl9bwg69mjxf3v-fractalide-env/share/racket/pkgs/fractalide/modules/rkt/rkt-fbp/scheduler.rkt:22:0: scheduler-match
   /nix/store/dm8yah829czzws2x6pkl9bwg69mjxf3v-fractalide-env/share/racket/pkgs/fractalide/modules/rkt/rkt-fbp/scheduler.rkt:197:0: scheduler-loop
```